### PR TITLE
Adds a pre-setup-hook 

### DIFF
--- a/src/TestingFramework/TestCase/FunctionalTestCase.php
+++ b/src/TestingFramework/TestCase/FunctionalTestCase.php
@@ -180,6 +180,12 @@ abstract class FunctionalTestCase extends AbstractTestCase
     }
 
     /**
+     * Pre set up hook after test system instance- and basic paths exist
+     * but before configuration is generated
+     */
+    public function preSetUpHook() {}
+
+    /**
      * Setup creates a test instance and database
      *
      * This method has to be called with parent::setUp() in your test cases
@@ -197,7 +203,8 @@ abstract class FunctionalTestCase extends AbstractTestCase
             $this->testExtensionsToLoad,
             $this->pathsToLinkInTestInstance,
             $this->configurationToUseInTestInstance,
-            $this->additionalFoldersToCreate
+            $this->additionalFoldersToCreate,
+            function() { return $this->preSetUpHook(); }
         );
     }
 

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -126,6 +126,7 @@ abstract class AbstractTestSystem
      * @param array $pathsToLinkInTestSystem Array of source => destination path pairs to be linked
      * @param array $configurationToUse Array of TYPO3_CONF_VARS that need to be overridden
      * @param array $additionalFoldersToCreate Array of folder paths to be created
+     * @param callable|null $preSetUpHook
      * @return void
      */
     public function setUp(
@@ -133,7 +134,8 @@ abstract class AbstractTestSystem
         array $testExtensionsToLoad,
         array $pathsToLinkInTestSystem,
         array $configurationToUse,
-        array $additionalFoldersToCreate
+        array $additionalFoldersToCreate,
+        $preSetUpHook = null
     ) {
         $this->registerNtfStreamWrapper();
         $this->setTypo3Context();
@@ -147,6 +149,7 @@ abstract class AbstractTestSystem
             $this->setUpSystemCoreLinks();
             $this->linkTestExtensionsToSystem($testExtensionsToLoad);
             $this->linkPathsInTestSystem($pathsToLinkInTestSystem);
+            if (is_callable($preSetUpHook)) { $preSetUpHook(); }
             $this->setUpLocalConfiguration($configurationToUse);
             $this->setUpPackageStates($coreExtensionsToLoad, $testExtensionsToLoad);
             $this->includeAndStartCoreBootstrap();


### PR DESCRIPTION
... for a functional test which is executed in the test-instance setUp method

* This hook adds the possibility e.g. to set up external configuration files fetched later by the environment context