### PR TITLE
Allows specific testing context

### DIFF
--- a/src/TestingFramework/Bootstrap/AbstractBootstrap.php
+++ b/src/TestingFramework/Bootstrap/AbstractBootstrap.php
@@ -41,7 +41,7 @@ abstract class AbstractBootstrap
      */
     public function __construct(CoreBootstrap $bootstrap = null)
     {
-        putenv('TYPO3_CONTEXT=Testing');
+        if (!preg_match('/^Testing\//', getenv('TYPO3_CONTEXT'))) { putenv('TYPO3_CONTEXT=Testing'); }
         $this->bootstrap = (null !== $bootstrap) ? $bootstrap : CoreBootstrap::getInstance();
     }
 

--- a/src/TestingFramework/TestSystem/AbstractTestSystem.php
+++ b/src/TestingFramework/TestSystem/AbstractTestSystem.php
@@ -97,7 +97,7 @@ abstract class AbstractTestSystem
      */
     public function __construct($identifier, Bootstrap $bootstrap = null)
     {
-        putenv('TYPO3_CONTEXT=Testing');
+        if (!preg_match('/^Testing\//', getenv('TYPO3_CONTEXT'))) { putenv('TYPO3_CONTEXT=Testing'); }
         $this->bootstrap = $bootstrap === null ? Bootstrap::getInstance() : $bootstrap;
         $this->identifier = substr(sha1($identifier), 0, 7);
         $this->systemPath = ORIGINAL_ROOT . 'typo3temp/var/tests/functional-' . $this->identifier . '/';


### PR DESCRIPTION
* By keeping the specific testing context like 'Testing/Production' we are able to load specific configurations